### PR TITLE
code_style extension: drop the BufWritePre autocmd

### DIFF
--- a/extensions/code_style/init.vim
+++ b/extensions/code_style/init.vim
@@ -1,5 +1,4 @@
 " whitespace cleaning
 let g:better_whitespace_filetypes_blacklist=['diff', 'gitcommit', 'unite', 'qf', 'help', 'far_vim', 'writable_search', 'vimfiler', 'vim-plug', 'leaderGuide']
-autocmd BufWritePre * StripWhitespace
 " tagbar
 nmap <F8> :TagbarToggle<CR>


### PR DESCRIPTION
There is no need to have an autocmd for stripping of trailing whitespace as the `vim-better-whitespace` plugin already handles that itself by default (more specifically, if the value of the `strip_whitespace_on_save` variable is set to `1`).